### PR TITLE
Fixed generateAttributeAST in CAMValues.java

### DIFF
--- a/src/ssmc/CAMValues.java
+++ b/src/ssmc/CAMValues.java
@@ -19,10 +19,12 @@ public class CAMValues {
 	 * @param unit ICompilationUnit input
 	 */
 	
-	public static void generateAttributeAST(ICompilationUnit unit) {
+	public static ArrayList<Attribute> generateAttributeAST(ICompilationUnit unit) {
 		final CompilationUnit cu = (CompilationUnit) parse(unit);
 		AttributeVisitor av = new AttributeVisitor(cu);
 		cu.accept(av);
+		
+		return av.getArrayList();
 	}
 
 	/**

--- a/src/ssmc/MethodVisitor.java
+++ b/src/ssmc/MethodVisitor.java
@@ -17,6 +17,7 @@ public class MethodVisitor extends ASTVisitor{
     public MethodVisitor(CompilationUnit cu){
         super();
         this.cu = cu;
+        methods = new ArrayList<Method>();
     }
 
     public boolean visit(MethodDeclaration node){  	


### PR DESCRIPTION
Merging Error_fixing with Master, should be fixing some errors with arraylists not being initilized